### PR TITLE
Add onUnhandledRejection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
-## [3.2.0] - 2021-9-30
+## [3.3.0] - 2022-04-25
+
+### Added
+- Add Promise.onUnhandledRejection global event
+
+## [3.2.0] - 2021-09-30
 
 ### Changed
 - Allow `Promise.all` to optionally accept multiple promises as varargs instead of an array (e4ba51e)

--- a/lib/init.spec.lua
+++ b/lib/init.spec.lua
@@ -34,6 +34,40 @@ return function()
 		end)
 	end)
 
+	describe("Unhandled rejection signal", function()
+		it("should call unhandled rejection callbacks", function()
+			local badPromise = Promise.new(function(_resolve, reject)
+				reject(1, 2)
+			end)
+
+			local callCount = 0
+
+			local function callback(promise, rejectionA, rejectionB)
+				callCount += 1
+
+				expect(promise).to.equal(badPromise)
+				expect(rejectionA).to.equal(1)
+				expect(rejectionB).to.equal(2)
+			end
+
+			local unregister = Promise.onUnhandledRejection(callback)
+
+			advanceTime()
+
+			expect(callCount).to.equal(1)
+
+			unregister()
+
+			Promise.new(function(_resolve, reject)
+				reject(3, 4)
+			end)
+
+			advanceTime()
+
+			expect(callCount).to.equal(1)
+		end)
+	end)
+
 	describe("Promise.new", function()
 		it("should instantiate with a callback", function()
 			local promise = Promise.new(function() end)

--- a/rotriever.toml
+++ b/rotriever.toml
@@ -1,7 +1,7 @@
 [package]
 name = "Promise"
-version = "3.2.1"
-author = "evaera"
+version = "3.3.0"
+authors = ["evaera"]
 license = "MIT"
 content_root = "lib"
 files = ["*.lua", "!*.spec.lua"]


### PR DESCRIPTION
Pulls in the onUnhandledRejection feature added to the upstream promise library (https://github.com/Roblox/roblox-lua-promise/commit/e4afc9eeee6d223a51452a38a36978ecf1844f70).

This will be helpful for test suites that currently have promise spam, as it provides a way to write custom logging that better serves the needs of folks cleaning up those tests.