### PR TITLE
LUAFDN-1417 Remove BindableEvent

### DIFF
--- a/lib/init.lua
+++ b/lib/init.lua
@@ -1109,14 +1109,15 @@ function Promise.prototype:awaitStatus()
 	self._unhandledRejection = false
 
 	if self._status == Promise.Status.Started then
-		local bindable = Instance.new("BindableEvent")
+		local currentCoroutine = coroutine.running()
 
 		self:finally(function()
-			bindable:Fire()
+			coroutine.wrap(function()
+				coroutine.resume(currentCoroutine)
+			end)()
 		end)
 
-		bindable.Event:Wait()
-		bindable:Destroy()
+		coroutine.yield()
 	end
 
 	if self._status == Promise.Status.Resolved then

--- a/lib/init.lua
+++ b/lib/init.lua
@@ -1109,12 +1109,10 @@ function Promise.prototype:awaitStatus()
 	self._unhandledRejection = false
 
 	if self._status == Promise.Status.Started then
-		local currentCoroutine = coroutine.running()
+		local thread = coroutine.running()
 
 		self:finally(function()
-			coroutine.wrap(function()
-				coroutine.resume(currentCoroutine)
-			end)()
+			task.spawn(thread)
 		end)
 
 		coroutine.yield()

--- a/lib/init.spec.lua
+++ b/lib/init.spec.lua
@@ -5,6 +5,11 @@ return function()
 	local timeEvent = Instance.new("BindableEvent")
 	Promise._timeEvent = timeEvent.Event
 
+	local function waitForEvents()
+		task.defer(coroutine.running())
+		coroutine.yield()
+	end
+
 	local advanceTime do
 		local injectedPromiseTime = 0
 
@@ -17,6 +22,7 @@ return function()
 
 			injectedPromiseTime = injectedPromiseTime + delta
 			timeEvent:Fire(delta)
+			waitForEvents()
 		end
 	end
 
@@ -157,6 +163,9 @@ return function()
 
 			expect(promise:getStatus()).to.equal(Promise.Status.Started)
 			bindable:Fire()
+
+			waitForEvents()
+
 			expect(promise:getStatus()).to.equal(Promise.Status.Resolved)
 			expect(promise._values[1]).to.equal(5)
 		end)
@@ -306,6 +315,7 @@ return function()
 
 			expect(promise:getStatus()).to.equal(Promise.Status.Started)
 			bindable:Fire()
+			waitForEvents()
 			expect(promise:getStatus()).to.equal(Promise.Status.Resolved)
 			expect(promise._values[1]).to.equal(5)
 		end)
@@ -1009,6 +1019,7 @@ return function()
 
 			expect(promise:getStatus()).to.equal(Promise.Status.Started)
 			bindable:Fire()
+			waitForEvents()
 			expect(promise:getStatus()).to.equal(Promise.Status.Rejected)
 			expect(tostring(promise._values[1]):find("errortext")).to.be.ok()
 		end)
@@ -1088,6 +1099,7 @@ return function()
 
 			expect(promise:getStatus()).to.equal(Promise.Status.Started)
 			bindable:Fire()
+			waitForEvents()
 			expect(promise:getStatus()).to.equal(Promise.Status.Rejected)
 			expect(tostring(promise._values[1]):find("errortext")).to.be.ok()
 		end)
@@ -1594,6 +1606,7 @@ return function()
 			expect(promise:getStatus()).to.equal(Promise.Status.Started)
 
 			event:Fire("foo")
+			waitForEvents()
 
 			expect(promise:getStatus()).to.equal(Promise.Status.Resolved)
 			expect(promise._values[1]).to.equal("foo")
@@ -1609,10 +1622,12 @@ return function()
 			expect(promise:getStatus()).to.equal(Promise.Status.Started)
 
 			event:Fire("bar")
+			waitForEvents()
 
 			expect(promise:getStatus()).to.equal(Promise.Status.Started)
 
 			event:Fire("foo")
+			waitForEvents()
 
 			expect(promise:getStatus()).to.equal(Promise.Status.Resolved)
 			expect(promise._values[1]).to.equal("foo")

--- a/runTests.server.lua
+++ b/runTests.server.lua
@@ -1,3 +1,5 @@
 require(script.Parent.TestEZ).TestBootstrap:run({
 	game.ServerScriptService.Lib
 })
+
+game:GetService("ProcessService"):ExitAsync(0)

--- a/test.project.json
+++ b/test.project.json
@@ -8,11 +8,8 @@
 				"$path": "lib"
 			}
 		},
-		"TestService": {
-			"$className": "TestService",
-			"$properties": {
-				"ExecuteWithStudioRun": true
-			},
+		"Workspace": {
+			"$className": "Workspace",
 			"TestEZ": {
 				"$path": "modules/testez/src"
 			},


### PR DESCRIPTION
To make sure the library resolves promises the same way when deferred
Lua is enabled, the BindableEvent fire pattern was removed.

In deferred Lua, since events are deferred at the end of the current
frame, awaiting on a BindableEvent.Event will defer the associate
coroutine 'later' than expected.