### PR TITLE
Align with upstream: import comments and rename parameters

### DIFF
--- a/lib/init.lua
+++ b/lib/init.lua
@@ -577,6 +577,9 @@ function Promise.all(...)
 		promises = promises[1]
 	end
 
+	return Promise._all(debug.traceback(nil, 2), promises)
+end
+
 --[=[
 	Folds an array of values or promises into a single value. The array is traversed sequentially.
 

--- a/lib/init.lua
+++ b/lib/init.lua
@@ -5,7 +5,7 @@
 local ERROR_NON_PROMISE_IN_LIST = "Non-promise value passed into %s at index %s"
 local ERROR_NON_LIST = "Please pass a list of promises to %s"
 local ERROR_NON_FUNCTION = "Please pass a handler function to %s!"
-local MODE_KEY_METATABLE = {__mode = "k"}
+local MODE_KEY_METATABLE = { __mode = "k" }
 
 --[[
 	Creates an enum dictionary with some metamethods to prevent common mistakes.
@@ -32,7 +32,8 @@ end
 	Promises that experience an error like this will be rejected with
 	an instance of this object.
 ]]
-local Error do
+local Error
+do
 	Error = {
 		Kind = makeEnum("Promise.Error.Kind", {
 			"ExecutionError",
@@ -98,10 +99,13 @@ local Error do
 		}
 
 		for _, runtimeError in ipairs(self:getErrorChain()) do
-			table.insert(errorStrings, table.concat({
-				runtimeError.trace or runtimeError.error,
-				runtimeError.context,
-			}, "\n"))
+			table.insert(
+				errorStrings,
+				table.concat({
+					runtimeError.trace or runtimeError.error,
+					runtimeError.context,
+				}, "\n")
+			)
 		end
 
 		return table.concat(errorStrings, "\n")
@@ -173,7 +177,7 @@ end
 
 local Promise = {
 	Error = Error,
-	Status = makeEnum("Promise.Status", {"Started", "Resolved", "Rejected", "Cancelled"}),
+	Status = makeEnum("Promise.Status", { "Started", "Resolved", "Rejected", "Cancelled" }),
 	_getTime = os.clock,
 	_timeEvent = game:GetService("RunService").Heartbeat,
 	_unhandledRejectionCallbacks = {},
@@ -259,13 +263,7 @@ function Promise._new(traceback, callback, parent)
 	end
 
 	coroutine.wrap(function()
-		local ok, _, result = runExecutor(
-			self._source,
-			callback,
-			resolve,
-			reject,
-			onCancel
-		)
+		local ok, _, result = runExecutor(self._source, callback, resolve, reject, onCancel)
 
 		if not ok then
 			reject(result[1])
@@ -412,21 +410,18 @@ function Promise._all(traceback, promises, amount)
 		-- We can assume the values inside `promises` are all promises since we
 		-- checked above.
 		for i, promise in ipairs(promises) do
-			newPromises[i] = promise:andThen(
-				function(...)
-					resolveOne(i, ...)
-				end,
-				function(...)
-					rejectedCount = rejectedCount + 1
+			newPromises[i] = promise:andThen(function(...)
+				resolveOne(i, ...)
+			end, function(...)
+				rejectedCount = rejectedCount + 1
 
-					if amount == nil or #promises - rejectedCount < amount then
-						cancel()
-						done = true
+				if amount == nil or #promises - rejectedCount < amount then
+					cancel()
+					done = true
 
-						reject(...)
-					end
+					reject(...)
 				end
-			)
+			end)
 		end
 
 		if done then
@@ -436,7 +431,7 @@ function Promise._all(traceback, promises, amount)
 end
 
 function Promise.all(...)
-	local promises = {...}
+	local promises = { ... }
 
 	-- check if we've been given a list of promises, not just a variable number of promises
 	if type(promises[1]) == "table" and not Promise.is(promises[1]) then
@@ -518,11 +513,9 @@ function Promise.allSettled(promises)
 		-- We can assume the values inside `promises` are all promises since we
 		-- checked above.
 		for i, promise in ipairs(promises) do
-			newPromises[i] = promise:finally(
-				function(...)
-					resolveOne(i, ...)
-				end
-			)
+			newPromises[i] = promise:finally(function(...)
+				resolveOne(i, ...)
+			end)
 		end
 	end)
 end
@@ -549,7 +542,7 @@ function Promise.race(promises)
 		end
 
 		local function finalize(callback)
-			return function (...)
+			return function(...)
 				cancel()
 				finished = true
 				return callback(...)
@@ -850,22 +843,12 @@ function Promise.prototype:_andThen(traceback, successHandler, failureHandler)
 
 		local successCallback = resolve
 		if successHandler then
-			successCallback = createAdvancer(
-				traceback,
-				successHandler,
-				resolve,
-				reject
-			)
+			successCallback = createAdvancer(traceback, successHandler, resolve, reject)
 		end
 
 		local failureCallback = reject
 		if failureHandler then
-			failureCallback = createAdvancer(
-				traceback,
-				failureHandler,
-				resolve,
-				reject
-			)
+			failureCallback = createAdvancer(traceback, failureHandler, resolve, reject)
 		end
 
 		if self._status == Promise.Status.Started then
@@ -1010,12 +993,7 @@ function Promise.prototype:_finally(traceback, finallyHandler, onlyOk)
 	return Promise._new(traceback, function(resolve, reject)
 		local finallyCallback = resolve
 		if finallyHandler then
-			finallyCallback = createAdvancer(
-				traceback,
-				finallyHandler,
-				resolve,
-				reject
-			)
+			finallyCallback = createAdvancer(traceback, finallyHandler, resolve, reject)
 		end
 
 		if onlyOk then
@@ -1187,8 +1165,7 @@ function Promise.prototype:_resolve(...)
 		-- Without this warning, arguments sometimes mysteriously disappear
 		if select("#", ...) > 1 then
 			local message = string.format(
-				"When returning a Promise from andThen, extra arguments are " ..
-				"discarded! See:\n\n%s",
+				"When returning a Promise from andThen, extra arguments are " .. "discarded! See:\n\n%s",
 				self._source
 			)
 			warn(message)
@@ -1196,36 +1173,33 @@ function Promise.prototype:_resolve(...)
 
 		local chainedPromise = ...
 
-		local promise = chainedPromise:andThen(
-			function(...)
-				self:_resolve(...)
-			end,
-			function(...)
-				local maybeRuntimeError = chainedPromise._values[1]
+		local promise = chainedPromise:andThen(function(...)
+			self:_resolve(...)
+		end, function(...)
+			local maybeRuntimeError = chainedPromise._values[1]
 
-				-- Backwards compatibility < v2
-				if chainedPromise._error then
-					maybeRuntimeError = Error.new({
-						error = chainedPromise._error,
-						kind = Error.Kind.ExecutionError,
-						context = "[No stack trace available as this Promise originated from an older version of the Promise library (< v2)]",
-					})
-				end
-
-				if Error.isKind(maybeRuntimeError, Error.Kind.ExecutionError) then
-					return self:_reject(maybeRuntimeError:extend({
-						error = "This Promise was chained to a Promise that errored.",
-						trace = "",
-						context = string.format(
-							"The Promise at:\n\n%s\n...Rejected because it was chained to the following Promise, which encountered an error:\n",
-							self._source
-						),
-					}))
-				end
-
-				self:_reject(...)
+			-- Backwards compatibility < v2
+			if chainedPromise._error then
+				maybeRuntimeError = Error.new({
+					error = chainedPromise._error,
+					kind = Error.Kind.ExecutionError,
+					context = "[No stack trace available as this Promise originated from an older version of the Promise library (< v2)]",
+				})
 			end
-		)
+
+			if Error.isKind(maybeRuntimeError, Error.Kind.ExecutionError) then
+				return self:_reject(maybeRuntimeError:extend({
+					error = "This Promise was chained to a Promise that errored.",
+					trace = "",
+					context = string.format(
+						"The Promise at:\n\n%s\n...Rejected because it was chained to the following Promise, which encountered an error:\n",
+						self._source
+					),
+				}))
+			end
+
+			self:_reject(...)
+		end)
 
 		if promise._status == Promise.Status.Cancelled then
 			self:cancel()
@@ -1280,11 +1254,7 @@ function Promise.prototype:_reject(...)
 			end
 
 			-- Build a reasonable message
-			local message = string.format(
-				"Unhandled Promise rejection:\n\n%s\n\n%s",
-				err,
-				self._source
-			)
+			local message = string.format("Unhandled Promise rejection:\n\n%s\n\n%s", err, self._source)
 
 			for _, callback in ipairs(Promise._unhandledRejectionCallbacks) do
 				task.spawn(callback, self, unpack(self._values, 1, self._valuesLength))
@@ -1352,7 +1322,7 @@ function Promise.retry(callback, times, ...)
 	assert(type(callback) == "function", "Parameter #1 to Promise.retry must be a function")
 	assert(type(times) == "number", "Parameter #2 to Promise.retry must be a number")
 
-	local args, length = {...}, select("#", ...)
+	local args, length = { ... }, select("#", ...)
 
 	return Promise.resolve(callback(...)):catch(function(...)
 		if times > 0 then

--- a/lib/init.lua
+++ b/lib/init.lua
@@ -27,11 +27,13 @@ local function makeEnum(enumName, members)
 	})
 end
 
---[[
+--[=[
 	An object to represent runtime errors that occur during execution.
 	Promises that experience an error like this will be rejected with
 	an instance of this object.
-]]
+
+	@class Error
+]=]
 local Error
 do
 	Error = {
@@ -175,6 +177,31 @@ local function isEmpty(t)
 	return next(t) == nil
 end
 
+--[=[
+	An enum value used to represent the Promise's status.
+	@interface Status
+	@tag enum
+	@within Promise
+	.Started "Started" -- The Promise is executing, and not settled yet.
+	.Resolved "Resolved" -- The Promise finished successfully.
+	.Rejected "Rejected" -- The Promise was rejected.
+	.Cancelled "Cancelled" -- The Promise was cancelled before it finished.
+]=]
+--[=[
+	@prop Status Status
+	@within Promise
+	@readonly
+	@tag enums
+	A table containing all members of the `Status` enum, e.g., `Promise.Status.Resolved`.
+]=]
+--[=[
+	A Promise is an object that represents a value that will exist in the future, but doesn't right now.
+	Promises allow you to then attach callbacks that can run once the value becomes available (known as *resolving*),
+	or if an error has occurred (known as *rejecting*).
+
+	@class Promise
+	@__index prototype
+]=]
 local Promise = {
 	Error = Error,
 	Status = makeEnum("Promise.Status", { "Started", "Resolved", "Rejected", "Cancelled" }),
@@ -185,18 +212,6 @@ local Promise = {
 Promise.prototype = {}
 Promise.__index = Promise.prototype
 
---[[
-	Constructs a new Promise with the given initializing callback.
-
-	This is generally only called when directly wrapping a non-promise API into
-	a promise-based version.
-
-	The callback will receive 'resolve' and 'reject' methods, used to start
-	invoking the promise chain.
-
-	Second parameter, parent, is used internally for tracking the "parent" in a
-	promise chain. External code shouldn't need to worry about this.
-]]
 function Promise._new(traceback, callback, parent)
 	if parent ~= nil and not Promise.is(parent) then
 		error("Argument #2 to Promise.new must be a promise or nil", 2)
@@ -273,6 +288,44 @@ function Promise._new(traceback, callback, parent)
 	return self
 end
 
+--[=[
+	Construct a new Promise that will be resolved or rejected with the given callbacks.
+
+	If you `resolve` with a Promise, it will be chained onto.
+
+	You can safely yield within the executor function and it will not block the creating thread.
+
+	```lua
+	local myFunction()
+		return Promise.new(function(resolve, reject, onCancel)
+			wait(1)
+			resolve("Hello world!")
+		end)
+	end
+
+	myFunction():andThen(print)
+	```
+
+	You do not need to use `pcall` within a Promise. Errors that occur during execution will be caught and turned into a rejection automatically. If `error()` is called with a table, that table will be the rejection value. Otherwise, string errors will be converted into `Promise.Error(Promise.Error.Kind.ExecutionError)` objects for tracking debug information.
+
+	You may register an optional cancellation hook by using the `onCancel` argument:
+
+	* This should be used to abort any ongoing operations leading up to the promise being settled.
+	* Call the `onCancel` function with a function callback as its only argument to set a hook which will in turn be called when/if the promise is cancelled.
+	* `onCancel` returns `true` if the Promise was already cancelled when you called `onCancel`.
+	* Calling `onCancel` with no argument will not override a previously set cancellation hook, but it will still return `true` if the Promise is currently cancelled.
+	* You can set the cancellation hook at any time before resolving.
+	* When a promise is cancelled, calls to `resolve` or `reject` will be ignored, regardless of if you set a cancellation hook or not.
+
+	:::caution
+	If the Promise is cancelled, the `executor` thread is closed with `coroutine.close` after the cancellation hook is called.
+
+	You must perform any cleanup code in the cancellation hook: any time your executor yields, it **may never resume**.
+	:::
+
+	@param executor (resolve: (...: any) -> (), reject: (...: any) -> (), onCancel: (abortHandler?: () -> ()) -> boolean) -> ()
+	@return Promise
+]=]
 function Promise.new(executor)
 	return Promise._new(debug.traceback(nil, 2), executor)
 end
@@ -281,9 +334,24 @@ function Promise:__tostring()
 	return string.format("Promise(%s)", self._status)
 end
 
---[[
-	Promise.new, except pcall on a new thread is automatic.
-]]
+--[=[
+	The same as [Promise.new](/api/Promise#new), except execution begins after the next `Heartbeat` event.
+
+	This is a spiritual replacement for `spawn`, but it does not suffer from the same [issues](https://eryn.io/gist/3db84579866c099cdd5bb2ff37947cec) as `spawn`.
+
+	```lua
+	local function waitForChild(instance, childName, timeout)
+	  return Promise.defer(function(resolve, reject)
+		local child = instance:WaitForChild(childName, timeout)
+
+		;(child and resolve or reject)(child)
+	  end)
+	end
+	```
+
+	@param executor (resolve: (...: any) -> (), reject: (...: any) -> (), onCancel: (abortHandler?: () -> ()) -> boolean) -> ()
+	@return Promise
+]=]
 function Promise.defer(callback)
 	local traceback = debug.traceback(nil, 2)
 	local promise
@@ -305,9 +373,28 @@ end
 -- Backwards compatibility
 Promise.async = Promise.defer
 
---[[
-	Create a promise that represents the immediately resolved value.
-]]
+--[=[
+	Creates an immediately resolved Promise with the given value.
+
+	```lua
+	-- Example using Promise.resolve to deliver cached values:
+	function getSomething(name)
+		if cache[name] then
+			return Promise.resolve(cache[name])
+		else
+			return Promise.new(function(resolve, reject)
+				local thing = getTheThing()
+				cache[name] = thing
+
+				resolve(thing)
+			end)
+		end
+	end
+	```
+
+	@param ... any
+	@return Promise<...any>
+]=]
 function Promise.resolve(...)
 	local length, values = pack(...)
 	return Promise._new(debug.traceback(nil, 2), function(resolve)
@@ -315,9 +402,16 @@ function Promise.resolve(...)
 	end)
 end
 
---[[
-	Create a promise that represents the immediately rejected value.
-]]
+--[=[
+	Creates an immediately rejected Promise with the given value.
+
+	:::caution
+	Something needs to consume this rejection (i.e. `:catch()` it), otherwise it will emit an unhandled Promise rejection warning on the next frame. Thus, you should not create and store rejected Promises for later use. Only create them on-demand as needed.
+	:::
+
+	@param ... any
+	@return Promise<...any>
+]=]
 function Promise.reject(...)
 	local length, values = pack(...)
 	return Promise._new(debug.traceback(nil, 2), function(_, reject)
@@ -337,9 +431,29 @@ function Promise._try(traceback, callback, ...)
 	end)
 end
 
---[[
-	Begins a Promise chain, turning synchronous errors into rejections.
-]]
+--[=[
+	Begins a Promise chain, calling a function and returning a Promise resolving with its return value. If the function errors, the returned Promise will be rejected with the error. You can safely yield within the Promise.try callback.
+
+	:::info
+	`Promise.try` is similar to [Promise.promisify](#promisify), except the callback is invoked immediately instead of returning a new function.
+	:::
+
+	```lua
+	Promise.try(function()
+		return math.random(1, 2) == 1 and "ok" or error("Oh an error!")
+	end)
+		:andThen(function(text)
+			print(text)
+		end)
+		:catch(function(err)
+			warn("Something went wrong")
+		end)
+	```
+
+	@param callback (...: T...) -> ...any
+	@param ... T... -- Additional arguments passed to `callback`
+	@return Promise
+]=]
 function Promise.try(...)
 	return Promise._try(debug.traceback(nil, 2), ...)
 end
@@ -430,6 +544,30 @@ function Promise._all(traceback, promises, amount)
 	end)
 end
 
+--[=[
+	Accepts an array of Promises and returns a new promise that:
+	* is resolved after all input promises resolve.
+	* is rejected if *any* input promises reject.
+
+	:::info
+	Only the first return value from each promise will be present in the resulting array.
+	:::
+
+	After any input Promise rejects, all other input Promises that are still pending will be cancelled if they have no other consumers.
+
+	```lua
+	local promises = {
+		returnsAPromise("example 1"),
+		returnsAPromise("example 2"),
+		returnsAPromise("example 3"),
+	}
+
+	return Promise.all(promises)
+	```
+
+	@param promises {Promise<T>}
+	@return Promise<{T}>
+]=]
 function Promise.all(...)
 	local promises = { ... }
 
@@ -439,9 +577,31 @@ function Promise.all(...)
 		promises = promises[1]
 	end
 
-	return Promise._all(debug.traceback(nil, 2), promises)
-end
+--[=[
+	Folds an array of values or promises into a single value. The array is traversed sequentially.
 
+	The reducer function can return a promise or value directly. Each iteration receives the resolved value from the previous, and the first receives your defined initial value.
+
+	The folding will stop at the first rejection encountered.
+	```lua
+	local basket = {"blueberry", "melon", "pear", "melon"}
+	Promise.fold(basket, function(cost, fruit)
+		if fruit == "blueberry" then
+			return cost -- blueberries are free!
+		else
+			-- call a function that returns a promise with the fruit price
+			return fetchPrice(fruit):andThen(function(fruitCost)
+				return cost + fruitCost
+			end)
+		end
+	end, 0)
+	```
+
+	@since v3.1.0
+	@param list {T | Promise<T>}
+	@param reducer (accumulator: U, value: T, index: number) -> U | Promise<U>
+	@param initialValue U
+]=]
 function Promise.fold(list, callback, initialValue)
 	assert(type(list) == "table", "Bad argument #1 to Promise.fold: must be a table")
 	assert(type(callback) == "function", "Bad argument #2 to Promise.fold: must be a function")
@@ -454,18 +614,71 @@ function Promise.fold(list, callback, initialValue)
 	end):andThenReturn(accumulator)
 end
 
+--[=[
+	Accepts an array of Promises and returns a Promise that is resolved as soon as `count` Promises are resolved from the input array. The resolved array values are in the order that the Promises resolved in. When this Promise resolves, all other pending Promises are cancelled if they have no other consumers.
+
+	`count` 0 results in an empty array. The resultant array will never have more than `count` elements.
+
+	```lua
+	local promises = {
+		returnsAPromise("example 1"),
+		returnsAPromise("example 2"),
+		returnsAPromise("example 3"),
+	}
+
+	return Promise.some(promises, 2) -- Only resolves with first 2 promises to resolve
+	```
+
+	@param promises {Promise<T>}
+	@param count number
+	@return Promise<{T}>
+]=]
 function Promise.some(promises, amount)
 	assert(type(amount) == "number", "Bad argument #2 to Promise.some: must be a number")
 
 	return Promise._all(debug.traceback(nil, 2), promises, amount)
 end
 
+--[=[
+	Accepts an array of Promises and returns a Promise that is resolved as soon as *any* of the input Promises resolves. It will reject only if *all* input Promises reject. As soon as one Promises resolves, all other pending Promises are cancelled if they have no other consumers.
+
+	Resolves directly with the value of the first resolved Promise. This is essentially [[Promise.some]] with `1` count, except the Promise resolves with the value directly instead of an array with one element.
+
+	```lua
+	local promises = {
+		returnsAPromise("example 1"),
+		returnsAPromise("example 2"),
+		returnsAPromise("example 3"),
+	}
+
+	return Promise.any(promises) -- Resolves with first value to resolve (only rejects if all 3 rejected)
+	```
+
+	@param promises {Promise<T>}
+	@return Promise<T>
+]=]
 function Promise.any(promises)
 	return Promise._all(debug.traceback(nil, 2), promises, 1):andThen(function(values)
 		return values[1]
 	end)
 end
 
+--[=[
+	Accepts an array of Promises and returns a new Promise that resolves with an array of in-place Statuses when all input Promises have settled. This is equivalent to mapping `promise:finally` over the array of Promises.
+
+	```lua
+	local promises = {
+		returnsAPromise("example 1"),
+		returnsAPromise("example 2"),
+		returnsAPromise("example 3"),
+	}
+
+	return Promise.allSettled(promises)
+	```
+
+	@param promises {Promise<T>}
+	@return Promise<{Status}>
+]=]
 function Promise.allSettled(promises)
 	if type(promises) ~= "table" then
 		error(string.format(ERROR_NON_LIST, "Promise.allSettled"), 2)
@@ -520,10 +733,30 @@ function Promise.allSettled(promises)
 	end)
 end
 
---[[
-	Races a set of Promises and returns the first one that resolves,
-	cancelling the others.
-]]
+--[=[
+	Accepts an array of Promises and returns a new promise that is resolved or rejected as soon as any Promise in the array resolves or rejects.
+
+	:::warning
+	If the first Promise to settle from the array settles with a rejection, the resulting Promise from `race` will reject.
+
+	If you instead want to tolerate rejections, and only care about at least one Promise resolving, you should use [Promise.any](#any) or [Promise.some](#some) instead.
+	:::
+
+	All other Promises that don't win the race will be cancelled if they have no other consumers.
+
+	```lua
+	local promises = {
+		returnsAPromise("example 1"),
+		returnsAPromise("example 2"),
+		returnsAPromise("example 3"),
+	}
+
+	return Promise.race(promises) -- Only returns 1st value to resolve or reject
+	```
+
+	@param promises {Promise<T>}
+	@return Promise<T>
+]=]
 function Promise.race(promises)
 	assert(type(promises) == "table", string.format(ERROR_NON_LIST, "Promise.race"))
 
@@ -563,14 +796,62 @@ function Promise.race(promises)
 	end)
 end
 
---[[
-	Iterates serially over the given an array of values, calling the predicate callback on each before continuing.
-	If the predicate returns a Promise, we wait for that Promise to resolve before continuing to the next item
-	in the array. If the Promise the predicate returns rejects, the Promise from Promise.each is also rejected with
-	the same value.
+--[=[
+	Iterates serially over the given an array of values, calling the predicate callback on each value before continuing.
 
-	Returns a Promise containing an array of the return values from the predicate for each item in the original list.
-]]
+	If the predicate returns a Promise, we wait for that Promise to resolve before moving on to the next item
+	in the array.
+
+	:::info
+	`Promise.each` is similar to `Promise.all`, except the Promises are ran in order instead of all at once.
+
+	But because Promises are eager, by the time they are created, they're already running. Thus, we need a way to defer creation of each Promise until a later time.
+
+	The predicate function exists as a way for us to operate on our data instead of creating a new closure for each Promise. If you would prefer, you can pass in an array of functions, and in the predicate, call the function and return its return value.
+	:::
+
+	```lua
+	Promise.each({
+		"foo",
+		"bar",
+		"baz",
+		"qux"
+	}, function(value, index)
+		return Promise.delay(1):andThen(function()
+		print(("%d) Got %s!"):format(index, value))
+		end)
+	end)
+
+	--[[
+		(1 second passes)
+		> 1) Got foo!
+		(1 second passes)
+		> 2) Got bar!
+		(1 second passes)
+		> 3) Got baz!
+		(1 second passes)
+		> 4) Got qux!
+	]]
+	```
+
+	If the Promise a predicate returns rejects, the Promise from `Promise.each` is also rejected with the same value.
+
+	If the array of values contains a Promise, when we get to that point in the list, we wait for the Promise to resolve before calling the predicate with the value.
+
+	If a Promise in the array of values is already Rejected when `Promise.each` is called, `Promise.each` rejects with that value immediately (the predicate callback will never be called even once). If a Promise in the list is already Cancelled when `Promise.each` is called, `Promise.each` rejects with `Promise.Error(Promise.Error.Kind.AlreadyCancelled`). If a Promise in the array of values is Started at first, but later rejects, `Promise.each` will reject with that value and iteration will not continue once iteration encounters that value.
+
+	Returns a Promise containing an array of the returned/resolved values from the predicate for each item in the array of values.
+
+	If this Promise returned from `Promise.each` rejects or is cancelled for any reason, the following are true:
+	- Iteration will not continue.
+	- Any Promises within the array of values will now be cancelled if they have no other consumers.
+	- The Promise returned from the currently active predicate will be cancelled if it hasn't resolved yet.
+
+	@since 3.0.0
+	@param list {T | Promise<T>}
+	@param predicate (value: T, index: number) -> U | Promise<U>
+	@return Promise<{U}>
+]=]
 function Promise.each(list, predicate)
 	assert(type(list) == "table", string.format(ERROR_NON_LIST, "Promise.each"))
 	assert(type(predicate) == "function", string.format(ERROR_NON_FUNCTION, "Promise.each"))
@@ -664,9 +945,12 @@ function Promise.each(list, predicate)
 	end)
 end
 
---[[
-	Is the given object a Promise instance?
-]]
+--[=[
+	Checks whether the given object is a Promise via duck typing. This only checks if the object is a table and has an `andThen` method.
+
+	@param object any
+	@return boolean -- `true` if the given `object` is a Promise.
+]=]
 function Promise.is(object)
 	if type(object) ~= "table" then
 		return false
@@ -692,18 +976,54 @@ function Promise.is(object)
 	return false
 end
 
---[[
-	Converts a yielding function into a Promise-returning one.
-]]
+--[=[
+	Wraps a function that yields into one that returns a Promise.
+
+	Any errors that occur while executing the function will be turned into rejections.
+
+	:::info
+	`Promise.promisify` is similar to [Promise.try](#try), except the callback is returned as a callable function instead of being invoked immediately.
+	:::
+
+	```lua
+	local sleep = Promise.promisify(wait)
+
+	sleep(1):andThen(print)
+	```
+
+	```lua
+	local isPlayerInGroup = Promise.promisify(function(player, groupId)
+		return player:IsInGroup(groupId)
+	end)
+	```
+
+	@param callback (...: any) -> ...any
+	@return (...: any) -> Promise
+]=]
 function Promise.promisify(callback)
 	return function(...)
 		return Promise._try(debug.traceback(nil, 2), callback, ...)
 	end
 end
 
---[[
-	Creates a Promise that resolves after given number of seconds.
-]]
+--[=[
+	Returns a Promise that resolves after `seconds` seconds have passed. The Promise resolves with the actual amount of time that was waited.
+
+	This function is **not** a wrapper around `wait`. `Promise.delay` uses a custom scheduler which provides more accurate timing. As an optimization, cancelling this Promise instantly removes the task from the scheduler.
+
+	:::warning
+	Passing `NaN`, infinity, or a number less than 1/60 is equivalent to passing 1/60.
+	:::
+
+	```lua
+		Promise.delay(5):andThenCall(print, "This prints after 5 seconds")
+	```
+
+	@function delay
+	@within Promise
+	@param seconds number
+	@return Promise<number>
+]=]
 do
 	-- uses a sorted doubly linked list (queue) to achieve O(1) remove operations and O(n) for insert
 
@@ -802,9 +1122,44 @@ do
 	end
 end
 
---[[
-	Rejects the promise after `seconds` seconds.
-]]
+--[=[
+	Returns a new Promise that resolves if the chained Promise resolves within `seconds` seconds, or rejects if execution time exceeds `seconds`. The chained Promise will be cancelled if the timeout is reached.
+
+	Rejects with `rejectionValue` if it is non-nil. If a `rejectionValue` is not given, it will reject with a `Promise.Error(Promise.Error.Kind.TimedOut)`. This can be checked with [[Error.isKind]].
+
+	```lua
+	getSomething():timeout(5):andThen(function(something)
+		-- got something and it only took at max 5 seconds
+	end):catch(function(e)
+		-- Either getting something failed or the time was exceeded.
+
+		if Promise.Error.isKind(e, Promise.Error.Kind.TimedOut) then
+			warn("Operation timed out!")
+		else
+			warn("Operation encountered an error!")
+		end
+	end)
+	```
+
+	Sugar for:
+
+	```lua
+	Promise.race({
+		Promise.delay(seconds):andThen(function()
+			return Promise.reject(
+				rejectionValue == nil
+				and Promise.Error.new({ kind = Promise.Error.Kind.TimedOut })
+				or rejectionValue
+			)
+		end),
+		promise
+	})
+	```
+
+	@param seconds number
+	@param rejectionValue? any -- The value to reject with if the timeout is reached
+	@return Promise
+]=]
 function Promise.prototype:timeout(seconds, rejectionValue)
 	local traceback = debug.traceback(nil, 2)
 
@@ -824,6 +1179,11 @@ function Promise.prototype:timeout(seconds, rejectionValue)
 	})
 end
 
+--[=[
+	Returns the current Promise status.
+
+	@return Status
+]=]
 function Promise.prototype:getStatus()
 	return self._status
 end
@@ -873,6 +1233,27 @@ function Promise.prototype:_andThen(traceback, successHandler, failureHandler)
 	end, self)
 end
 
+--[=[
+	Chains onto an existing Promise and returns a new Promise.
+
+	:::warning
+	Within the failure handler, you should never assume that the rejection value is a string. Some rejections within the Promise library are represented by [[Error]] objects. If you want to treat it as a string for debugging, you should call `tostring` on it first.
+	:::
+
+	You can return a Promise from the success or failure handler and it will be chained onto.
+
+	Calling `andThen` on a cancelled Promise returns a cancelled Promise.
+
+	:::tip
+	If the Promise returned by `andThen` is cancelled, `successHandler` and `failureHandler` will not run.
+
+	To run code no matter what, use [Promise:finally].
+	:::
+
+	@param successHandler (...: any) -> ...any
+	@param failureHandler? (...: any) -> ...any
+	@return Promise<...any>
+]=]
 function Promise.prototype:andThen(successHandler, failureHandler)
 	assert(
 		successHandler == nil or type(successHandler) == "function" or successHandler.__call ~= nil,
@@ -886,9 +1267,26 @@ function Promise.prototype:andThen(successHandler, failureHandler)
 	return self:_andThen(debug.traceback(nil, 2), successHandler, failureHandler)
 end
 
---[[
-	Used to catch any errors that may have occurred in the promise.
-]]
+--[=[
+	Shorthand for `Promise:andThen(nil, failureHandler)`.
+
+	Returns a Promise that resolves if the `failureHandler` worked without encountering an additional error.
+
+	:::warning
+	Within the failure handler, you should never assume that the rejection value is a string. Some rejections within the Promise library are represented by [[Error]] objects. If you want to treat it as a string for debugging, you should call `tostring` on it first.
+	:::
+
+	Calling `catch` on a cancelled Promise returns a cancelled Promise.
+
+	:::tip
+	If the Promise returned by `catch` is cancelled,  `failureHandler` will not run.
+
+	To run code no matter what, use [Promise:finally].
+	:::
+
+	@param failureHandler (...: any) -> ...any
+	@return Promise<...any>
+]=]
 function Promise.prototype:catch(failureCallback)
 	assert(
 		failureCallback == nil or type(failureCallback) == "function" or failureCallback.__call ~= nil,
@@ -897,10 +1295,22 @@ function Promise.prototype:catch(failureCallback)
 	return self:_andThen(debug.traceback(nil, 2), nil, failureCallback)
 end
 
---[[
-	Like andThen, but the value passed into the handler is also the
-	value returned from the handler.
-]]
+--[=[
+	Similar to [Promise.andThen](#andThen), except the return value is the same as the value passed to the handler. In other words, you can insert a `:tap` into a Promise chain without affecting the value that downstream Promises receive.
+
+	```lua
+		getTheValue()
+		:tap(print)
+		:andThen(function(theValue)
+			print("Got", theValue, "even though print returns nil!")
+		end)
+	```
+
+	If you return a Promise from the tap handler callback, its value will be discarded but `tap` will still wait until it resolves before passing the original value through.
+
+	@param tapHandler (...: any) -> ...any
+	@return Promise<...any>
+]=]
 function Promise.prototype:tap(tapCallback)
 	assert(type(tapCallback) == "function", string.format(ERROR_NON_FUNCTION, "Promise:tap"))
 	return self:_andThen(debug.traceback(nil, 2), function(...)
@@ -917,9 +1327,25 @@ function Promise.prototype:tap(tapCallback)
 	end)
 end
 
---[[
-	Calls a callback on `andThen` with specific arguments.
-]]
+--[=[
+	Attaches an `andThen` handler to this Promise that calls the given callback with the predefined arguments. The resolved value is discarded.
+
+	```lua
+		promise:andThenCall(someFunction, "some", "arguments")
+	```
+
+	This is sugar for
+
+	```lua
+		promise:andThen(function()
+		return someFunction("some", "arguments")
+		end)
+	```
+
+	@param callback (...: any) -> any
+	@param ...? any -- Additional arguments which will be passed to `callback`
+	@return Promise
+]=]
 function Promise.prototype:andThenCall(callback, ...)
 	assert(type(callback) == "function", string.format(ERROR_NON_FUNCTION, "Promise:andThenCall"))
 	local length, values = pack(...)
@@ -928,9 +1354,28 @@ function Promise.prototype:andThenCall(callback, ...)
 	end)
 end
 
---[[
-	Shorthand for an andThen handler that returns the given value.
-]]
+--[=[
+	Attaches an `andThen` handler to this Promise that discards the resolved value and returns the given value from it.
+
+	```lua
+		promise:andThenReturn("some", "values")
+	```
+
+	This is sugar for
+
+	```lua
+		promise:andThen(function()
+			return "some", "values"
+		end)
+	```
+
+	:::caution
+	Promises are eager, so if you pass a Promise to `andThenReturn`, it will begin executing before `andThenReturn` is reached in the chain. Likewise, if you pass a Promise created from [[Promise.reject]] into `andThenReturn`, it's possible that this will trigger the unhandled rejection warning. If you need to return a Promise, it's usually best practice to use [[Promise.andThen]].
+	:::
+
+	@param ... any -- Values to return from the function
+	@return Promise
+]=]
 function Promise.prototype:andThenReturn(...)
 	local length, values = pack(...)
 	return self:_andThen(debug.traceback(nil, 2), function()
@@ -938,10 +1383,17 @@ function Promise.prototype:andThenReturn(...)
 	end)
 end
 
---[[
-	Cancels the promise, disallowing it from rejecting or resolving, and calls
-	the cancellation hook if provided.
-]]
+--[=[
+	Cancels this promise, preventing the promise from resolving or rejecting. Does not do anything if the promise is already settled.
+
+	Cancellations will propagate upwards and downwards through chained promises.
+
+	Promises will only be cancelled if all of their consumers are also cancelled. This is to say that if you call `andThen` twice on the same promise, and you cancel only one of the child promises, it will not cancel the parent promise until the other child promise is also cancelled.
+
+	```lua
+		promise:cancel()
+	```
+]=]
 function Promise.prototype:cancel()
 	if self._status ~= Promise.Status.Started then
 		return
@@ -982,7 +1434,7 @@ end
 
 --[[
 	Used to set a handler for when the promise resolves, rejects, or is
-	cancelled. Returns a new promise chained from this promise.
+	cancelled.
 ]]
 function Promise.prototype:_finally(traceback, finallyHandler, onlyOk)
 	if not onlyOk then
@@ -1017,6 +1469,55 @@ function Promise.prototype:_finally(traceback, finallyHandler, onlyOk)
 	end, self)
 end
 
+--[=[
+	Set a handler that will be called regardless of the promise's fate. The handler is called when the promise is
+	resolved, rejected, *or* cancelled.
+
+	Returns a new Promise that:
+	- resolves with the same values that this Promise resolves with.
+	- rejects with the same values that this Promise rejects with.
+	- is cancelled if this Promise is cancelled.
+
+	If the value you return from the handler is a Promise:
+	- We wait for the Promise to resolve, but we ultimately discard the resolved value.
+	- If the returned Promise rejects, the Promise returned from `finally` will reject with the rejected value from the
+	*returned* promise.
+	- If the `finally` Promise is cancelled, and you returned a Promise from the handler, we cancel that Promise too.
+
+	Otherwise, the return value from the `finally` handler is entirely discarded.
+
+	:::note Cancellation
+	As of Promise v4, `Promise:finally` does not count as a consumer of the parent Promise for cancellation purposes.
+	This means that if all of a Promise's consumers are cancelled and the only remaining callbacks are finally handlers,
+	the Promise is cancelled and the finally callbacks run then and there.
+
+	Cancellation still propagates through the `finally` Promise though: if you cancel the `finally` Promise, it can cancel
+	its parent Promise if it had no other consumers. Likewise, if the parent Promise is cancelled, the `finally` Promise
+	will also be cancelled.
+	:::
+
+	```lua
+	local thing = createSomething()
+
+	doSomethingWith(thing)
+		:andThen(function()
+			print("It worked!")
+			-- do something..
+		end)
+		:catch(function()
+			warn("Oh no it failed!")
+		end)
+		:finally(function()
+			-- either way, destroy thing
+
+			thing:Destroy()
+		end)
+
+	```
+
+	@param finallyHandler (status: Status) -> ...any
+	@return Promise<...any>
+]=]
 function Promise.prototype:finally(finallyHandler)
 	assert(
 		finallyHandler == nil or type(finallyHandler) == "function" or finallyHandler.__call ~= nill,
@@ -1025,9 +1526,15 @@ function Promise.prototype:finally(finallyHandler)
 	return self:_finally(debug.traceback(nil, 2), finallyHandler)
 end
 
---[[
-	Calls a callback on `finally` with specific arguments.
-]]
+--[=[
+	Same as `andThenCall`, except for `finally`.
+
+	Attaches a `finally` handler to this Promise that calls the given callback with the predefined arguments.
+
+	@param callback (...: any) -> any
+	@param ...? any -- Additional arguments which will be passed to `callback`
+	@return Promise
+]=]
 function Promise.prototype:finallyCall(callback, ...)
 	assert(type(callback) == "function", string.format(ERROR_NON_FUNCTION, "Promise:finallyCall"))
 	local length, values = pack(...)
@@ -1036,9 +1543,24 @@ function Promise.prototype:finallyCall(callback, ...)
 	end)
 end
 
---[[
-	Shorthand for a finally handler that returns the given value.
-]]
+--[=[
+	Attaches a `finally` handler to this Promise that discards the resolved value and returns the given value from it.
+
+	```lua
+		promise:finallyReturn("some", "values")
+	```
+
+	This is sugar for
+
+	```lua
+		promise:finally(function()
+			return "some", "values"
+		end)
+	```
+
+	@param ... any -- Values to return from the function
+	@return Promise
+]=]
 function Promise.prototype:finallyReturn(...)
 	local length, values = pack(...)
 	return self:_finally(debug.traceback(nil, 2), function()
@@ -1078,11 +1600,13 @@ function Promise.prototype:doneReturn(...)
 	end, true)
 end
 
---[[
-	Yield until the promise is completed.
+--[=[
+	Yields the current thread until the given Promise completes. Returns the Promise's status, followed by the values that the promise resolved or rejected with.
 
-	This matches the execution model of normal Roblox functions.
-]]
+	@yields
+	@return Status -- The Status representing the fate of the Promise
+	@return ...any -- The values the Promise resolved or rejected with.
+]=]
 function Promise.prototype:awaitStatus()
 	self._unhandledRejection = false
 
@@ -1109,9 +1633,27 @@ local function awaitHelper(status, ...)
 	return status == Promise.Status.Resolved, ...
 end
 
---[[
-	Calls awaitStatus internally, returns (isResolved, values...)
-]]
+--[=[
+	Yields the current thread until the given Promise completes. Returns true if the Promise resolved, followed by the values that the promise resolved or rejected with.
+
+	:::caution
+	If the Promise gets cancelled, this function will return `false`, which is indistinguishable from a rejection. If you need to differentiate, you should use [[Promise.awaitStatus]] instead.
+	:::
+
+	```lua
+		local worked, value = getTheValue():await()
+
+	if worked then
+		print("got", value)
+	else
+		warn("it failed")
+	end
+	```
+
+	@yields
+	@return boolean -- `true` if the Promise successfully resolved
+	@return ...any -- The values the Promise resolved or rejected with.
+]=]
 function Promise.prototype:await()
 	return awaitHelper(self:awaitStatus())
 end
@@ -1124,10 +1666,31 @@ local function expectHelper(status, ...)
 	return ...
 end
 
---[[
-	Calls await and only returns if the Promise resolves.
-	Throws if the Promise rejects or gets cancelled.
-]]
+--[=[
+	Yields the current thread until the given Promise completes. Returns the values that the promise resolved with.
+
+	```lua
+	local worked = pcall(function()
+		print("got", getTheValue():expect())
+	end)
+
+	if not worked then
+		warn("it failed")
+	end
+	```
+
+	This is essentially sugar for:
+
+	```lua
+	select(2, assert(promise:await()))
+	```
+
+	**Errors** if the Promise rejects or gets cancelled.
+
+	@error any -- Errors with the rejection value if this Promise rejects or gets cancelled.
+	@yields
+	@return ...any -- The values the Promise resolved with.
+]=]
 function Promise.prototype:expect()
 	return expectHelper(self:awaitStatus())
 end
@@ -1296,10 +1859,22 @@ function Promise.prototype:_finalize()
 	end
 end
 
---[[
-	Chains a Promise from this one that is resolved if this Promise is
-	resolved, and rejected if it is not resolved.
-]]
+--[=[
+	Chains a Promise from this one that is resolved if this Promise is already resolved, and rejected if it is not resolved at the time of calling `:now()`. This can be used to ensure your `andThen` handler occurs on the same frame as the root Promise execution.
+
+	```lua
+	doSomething()
+		:now()
+		:andThen(function(value)
+			print("Got", value, "synchronously.")
+		end)
+	```
+
+	If this Promise is still running, Rejected, or Cancelled, the Promise returned from `:now()` will reject with the `rejectionValue` if passed, otherwise with a `Promise.Error(Promise.Error.Kind.NotResolvedInTime)`. This can be checked with [[Error.isKind]].
+
+	@param rejectionValue? any -- The value to reject with if the Promise isn't resolved
+	@return Promise
+]=]
 function Promise.prototype:now(rejectionValue)
 	local traceback = debug.traceback(nil, 2)
 	if self._status == Promise.Status.Resolved then
@@ -1315,9 +1890,36 @@ function Promise.prototype:now(rejectionValue)
 	end
 end
 
---[[
-	Retries a Promise-returning callback N times until it succeeds.
-]]
+--[=[
+	Repeatedly calls a Promise-returning function up to `times` number of times, until the returned Promise resolves.
+
+	If the amount of retries is exceeded, the function will return the latest rejected Promise.
+
+	```lua
+	local function canFail(a, b, c)
+		return Promise.new(function(resolve, reject)
+			-- do something that can fail
+
+			local failed, thing = doSomethingThatCanFail(a, b, c)
+
+			if failed then
+				reject("it failed")
+			else
+				resolve(thing)
+			end
+		end)
+	end
+
+	local MAX_RETRIES = 10
+	local value = Promise.retry(canFail, MAX_RETRIES, "foo", "bar", "baz") -- args to send to canFail
+	```
+
+	@since 3.0.0
+	@param callback (...: P) -> Promise<T>
+	@param times number
+	@param ...? P
+	@return Promise<T>
+]=]
 function Promise.retry(callback, times, ...)
 	assert(type(callback) == "function", "Parameter #1 to Promise.retry must be a function")
 	assert(type(times) == "number", "Parameter #2 to Promise.retry must be a number")
@@ -1333,9 +1935,30 @@ function Promise.retry(callback, times, ...)
 	end)
 end
 
---[[
-	Converts an event into a Promise with an optional predicate
-]]
+--[=[
+	Converts an event into a Promise which resolves the next time the event fires.
+
+	The optional `predicate` callback, if passed, will receive the event arguments and should return `true` or `false`, based on if this fired event should resolve the Promise or not. If `true`, the Promise resolves. If `false`, nothing happens and the predicate will be rerun the next time the event fires.
+
+	The Promise will resolve with the event arguments.
+
+	:::tip
+	This function will work given any object with a `Connect` method. This includes all Roblox events.
+	:::
+
+	```lua
+	-- Creates a Promise which only resolves when `somePart` is touched
+	-- by a part named `"Something specific"`.
+	return Promise.fromEvent(somePart.Touched, function(part)
+		return part.Name == "Something specific"
+	end)
+	```
+
+	@since 3.0.0
+	@param event Event -- Any object with a `Connect` method. This includes all Roblox events.
+	@param predicate? (...: P) -> boolean -- A function which determines if the Promise should resolve with the given value, or wait for the next event to check again.
+	@return Promise<P>
+]=]
 function Promise.fromEvent(event, predicate)
 	predicate = predicate or function()
 		return true
@@ -1384,6 +2007,7 @@ end
 
 	The callback is called with the actual promise that rejected, followed by the rejection values.
 
+	@since v3.2.0
 	@param callback (promise: Promise, ...: any) -- A callback that runs when an unhandled rejection happens.
 	@return () -> () -- Function that unregisters the `callback` when called
 ]=]


### PR DESCRIPTION
These changes should be limited to comments and some parameter renaming.

I'll make a follow-up that aligns a few more things that should all be noops 🔧 