### PR TITLE
Fix finalize hitting max deferred event queue size limit

### DIFF
--- a/lib/init.lua
+++ b/lib/init.lua
@@ -6,10 +6,12 @@ local ERROR_NON_PROMISE_IN_LIST = "Non-promise value passed into %s at index %s"
 local ERROR_NON_LIST = "Please pass a list of promises to %s"
 local ERROR_NON_FUNCTION = "Please pass a handler function to %s!"
 local MODE_KEY_METATABLE = { __mode = "k" }
-local Packages = script.Parent
-local SafeFlags = require(Packages.SafeFlags)
 
-local FFlagReducePromiseTaskDefer = SafeFlags.createGetFFlag("ReducePromiseTaskDefer")()
+local success, FFlagReducePromiseTaskDefer = pcall(game.DefineFastFlag, game, "ReducePromiseTaskDefer", false)
+
+if not success then
+	FFlagReducePromiseTaskDefer = false
+end
 
 local function isCallable(value)
 	if type(value) == "function" then

--- a/lib/init.lua
+++ b/lib/init.lua
@@ -6,6 +6,10 @@ local ERROR_NON_PROMISE_IN_LIST = "Non-promise value passed into %s at index %s"
 local ERROR_NON_LIST = "Please pass a list of promises to %s"
 local ERROR_NON_FUNCTION = "Please pass a handler function to %s!"
 local MODE_KEY_METATABLE = { __mode = "k" }
+local Packages = script.Parent
+local SafeFlags = require(Packages.SafeFlags)
+
+local FFlagReducePromiseTaskDefer = SafeFlags.createGetFFlag("ReducePromiseTaskDefer")()
 
 local function isCallable(value)
 	if type(value) == "function" then
@@ -1929,9 +1933,13 @@ do
 			self._consumers = nil
 		end
 
-		table.insert(threadsToClose, self._thread)
-		if not closingTask then
-			closingTask = task.defer(closeThreads)
+		if FFlagReducePromiseTaskDefer then
+			table.insert(threadsToClose, self._thread)
+			if not closingTask then
+				closingTask = task.defer(closeThreads)
+			end
+		else
+			task.defer(coroutine.close, self._thread)
 		end
 	end
 end

--- a/rotriever.toml
+++ b/rotriever.toml
@@ -1,6 +1,6 @@
 [package]
 name = "Promise"
-version = "3.5.0"
+version = "3.5.1"
 authors = ["evaera"]
 license = "MIT"
 content_root = "lib"

--- a/rotriever.toml
+++ b/rotriever.toml
@@ -5,3 +5,6 @@ authors = ["evaera"]
 license = "MIT"
 content_root = "lib"
 files = ["*.lua", "!*.spec.lua"]
+
+[config]
+registry_index = true


### PR DESCRIPTION
# Problem
For N promises that are finalized in the same frame, N `task.defer`s are created to close the threads. This can create a huge amount of events hitting a maximum limit in engine. 

# Solution
Combine all thread closes into a single deferred callback. This reduces the N `task.defer`s to 1.